### PR TITLE
ApiKeyCheck implementation

### DIFF
--- a/js/ApiKeyChecker.js
+++ b/js/ApiKeyChecker.js
@@ -1,58 +1,60 @@
 const apiKeyError = {
 	"NO_ERROR":0,
-	"KEY_IS_UNDEFINED":1,
+	"KEY_IS_UNDEFINED_OR_NOT_A_STRING":1,
 	"KEY_IS_EMPTY":2,
-	"KEY_IS_NOT_ONLY_LOWERCASE_HEXADECIMALS":3,
-	"KEY_DOES_NOT_CONTAIN_EXACTLY_32_CHARACTERS":4
+	"KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS":3
 };
 Object.freeze(apiKeyError);
 
-class ApiKeyChecker {
 
-	//TODO: Implement this function correctly.
-	static checkDiscourseApiKey(apiKey) {
+/**
+ * Check if the apiKey has the right format before using it.
+	 * @param {string} apiKey
+	 * @return {Object} success, error, errorMsg, formattedKey
+	 */
+function checkDiscourseApiKey(apiKey) {
 
-		//check if key is defined
-		if (true) {
-			return {
-				success : false,
-				error : apiKeyError.KEY_IS_UNDEFINED,
-				errorMsg : "'UserApiKey' is not defined in config.js.",
-			};
-		}
+	//check if key is defined
+	if (typeof apiKey == "undefined") {
 
-		//check if key is not empty
-		if (true) {
-			return {
-				success : false,
-				error : apiKeyError.KEY_IS_EMPTY,
-				errorMsg : "'UserApiKey' in config.js is an empty string.",
-			};
-		}
-
-		//check if key is a lowercase hexadecimal string
-		if (true) {
-			return {
-				success : false,
-				error : apiKeyError.KEY_IS_NOT_ONLY_LOWERCASE_HEXADECIMALS,
-				errorMsg : "The provided API key has a wrong format. It should only contain lowercase hexadecimals.",
-			};
-		}
-
-		//check if key has a length of 32
-		if (true) {
-			return {
-				success : false,
-				error : apiKeyError.KEY_DOES_NOT_CONTAIN_EXACTLY_32_CHARACTERS,
-				errorMsg : "Invalid API key length. It should be 32 characters long.",
-			};
-		}
-
-		//Check passed.
 		return {
-			success : true,
-			error : apiKeyError.NO_ERROR,
-			errorMsg : "No error",
+			success : false,
+			error : apiKeyError.KEY_IS_UNDEFINED_OR_NOT_A_STRING,
+			errorMsg : "'UserApiKey' is not defined in config.js or is not a string.",
 		};
 	}
+
+	apiKey = apiKey.toLowerCase();
+
+	//Remove spaces at the start and end of the key.
+	apiKey = apiKey.trim();
+
+	//check if key is not empty
+	if (apiKey.length === 0) {
+		return {
+			success : false,
+			error : apiKeyError.KEY_IS_EMPTY,
+			errorMsg : "'UserApiKey' in config.js is an empty string.",
+		};
+	}
+
+
+	//check if key is a lowercase hexadecimal string
+	if (apiKey.match("^[a-f0-9]{32}$") === null) {
+		return {
+			success : false,
+			error : apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS,
+			errorMsg : "The provided API key has a wrong format. It should be a string of 32 hexadecimal numbers.",
+		};
+	}
+
+	//Check passed.
+	return {
+		success : true,
+		error : apiKeyError.NO_ERROR,
+		errorMsg : "No error",
+		formattedKey : apiKey,
+	};
 }
+
+module.exports = {apiKeyError, checkDiscourseApiKey};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A MagicMirror module that shows your notifications for websites that use the Discourse platform.",
   "main": "index.js",
   "scripts": {
-    "test": "karma start --single-run && npx eslint *.js"
+    "test": "npx eslint *.js"
   },
   "repository": {
     "type": "git",

--- a/tests/validateUserApiKey_test.js
+++ b/tests/validateUserApiKey_test.js
@@ -1,4 +1,4 @@
-/* global ApiKeyChecker apiKeyError */
+/* global apiKeyError */
 /* eslint-disable jasmine/no-pending-tests */
 
 describe("The API key validator", function() {
@@ -6,10 +6,10 @@ describe("The API key validator", function() {
 	describe("Checks for undefined strings", function() {
 
 		it("should return false when the string is undefined.", function () {
-			let result = ApiKeyChecker.checkDiscourseApiKey(undefined);
+			let result = checkDiscourseApiKey(undefined);
 
 			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_IS_UNDEFINED);
+			expect(result.error).toBe(apiKeyError.KEY_IS_UNDEFINED_OR_NOT_A_STRING);
 		});
 
 	});
@@ -17,12 +17,12 @@ describe("The API key validator", function() {
 	describe("Checks for empty strings", function() {
 
 		it("should return false when the string is defined but empty.", function () {
-			let result = ApiKeyChecker.checkDiscourseApiKey("");
+			let result = checkDiscourseApiKey("");
 
 			expect(result.success).toBe(false);
 			expect(result.error).toBe(apiKeyError.KEY_IS_EMPTY);
 
-			result = ApiKeyChecker.checkDiscourseApiKey("      ");
+			result = checkDiscourseApiKey("      ");
 
 			expect(result.success).toBe(false);
 			expect(result.error).toBe(apiKeyError.KEY_IS_EMPTY);
@@ -32,133 +32,149 @@ describe("The API key validator", function() {
 
 	describe("Checks for hexadecimals. (spaces on the side must be trimmed)", function() {
 
-		it("should return false when the key is not in HEX.", function () {
+		it("should return false when the key is not a (HEX) string of 32 characters.", function () {
 
-			let result = ApiKeyChecker.checkDiscourseApiKey("abcdefg12345678");
-			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_IS_NOT_ONLY_LOWERCASE_HEXADECIMALS);
+			let result = checkDiscourseApiKey("abcdefg12345678");
 
-			result = ApiKeyChecker.checkDiscourseApiKey("3820235820efa0i");
 			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_IS_NOT_ONLY_LOWERCASE_HEXADECIMALS);
+			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
 
-			result = ApiKeyChecker.checkDiscourseApiKey("true");
-			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_IS_NOT_ONLY_LOWERCASE_HEXADECIMALS);
+			result = checkDiscourseApiKey("3820235820efa0i");
 
-			result = ApiKeyChecker.checkDiscourseApiKey("z");
 			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_IS_NOT_ONLY_LOWERCASE_HEXADECIMALS);
+			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
 
-			result = ApiKeyChecker.checkDiscourseApiKey("helloworld");
-			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_IS_NOT_ONLY_LOWERCASE_HEXADECIMALS);
+			result = checkDiscourseApiKey("true");
 
-			result = ApiKeyChecker.checkDiscourseApiKey("000000000000000t0");
 			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_IS_NOT_ONLY_LOWERCASE_HEXADECIMALS);
+			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
+
+			result = checkDiscourseApiKey("z");
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
+
+			result = checkDiscourseApiKey("helloworld");
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
+
+			result = checkDiscourseApiKey("000000000000000t0");
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
 		});
 
 		it("should return false when the key contains spaces in the middle.", function () {
 
-			let result = ApiKeyChecker.checkDiscourseApiKey("1 2345678901234567890123456789012");
-			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_IS_NOT_ONLY_LOWERCASE_HEXADECIMALS);
+			let result = checkDiscourseApiKey("1 2345678901234567890123456789012");
 
-			result = ApiKeyChecker.checkDiscourseApiKey("1234567890123456789012345678901 2 ");
 			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_IS_NOT_ONLY_LOWERCASE_HEXADECIMALS);
+			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
 
-			result = ApiKeyChecker.checkDiscourseApiKey("1234567890123               4567890123456789012");
-			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_IS_NOT_ONLY_LOWERCASE_HEXADECIMALS);
+			result = checkDiscourseApiKey("1234567890123456789012345678901 2 ");
 
-			result = ApiKeyChecker.checkDiscourseApiKey("1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2");
 			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_IS_NOT_ONLY_LOWERCASE_HEXADECIMALS);
+			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
+
+			result = checkDiscourseApiKey("1234567890123               4567890123456789012");
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
+
+			result = checkDiscourseApiKey("1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2");
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
 		});
 
 	});
 
-	describe("Checks for the correct amound of characters. (spaces on the side must be trimmed)", function() {
+	describe("Checks for the correct amount of characters. (spaces on the side must be trimmed)", function() {
 
 		it("should return false when the key does not contain 32 characters.", function () {
 
-			let result = ApiKeyChecker.checkDiscourseApiKey("1");
-			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_CONTAIN_EXACTLY_32_CHARACTERS);
+			let result = checkDiscourseApiKey("1");
 
-			result = ApiKeyChecker.checkDiscourseApiKey("123456789012345678901234567890123");
 			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_CONTAIN_EXACTLY_32_CHARACTERS);
+			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
 
-			result = ApiKeyChecker.checkDiscourseApiKey("1234567890123456789012345678901");
-			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_CONTAIN_EXACTLY_32_CHARACTERS);
+			result = checkDiscourseApiKey("123456789012345678901234567890123");
 
-			result = ApiKeyChecker.checkDiscourseApiKey("0123456789abcdef0123456789abcdef0");
 			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_CONTAIN_EXACTLY_32_CHARACTERS);
+			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
 
-			result = ApiKeyChecker.checkDiscourseApiKey("0123456789abcdef0123456789abcde");
-			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_CONTAIN_EXACTLY_32_CHARACTERS);
+			result = checkDiscourseApiKey("1234567890123456789012345678901");
 
-			result = ApiKeyChecker.checkDiscourseApiKey("   0123456789abcdef0123456789   ");
 			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_CONTAIN_EXACTLY_32_CHARACTERS);
+			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
+
+			result = checkDiscourseApiKey("0123456789abcdef0123456789abcdef0");
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
+
+			result = checkDiscourseApiKey("0123456789abcdef0123456789abcde");
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
+
+			result = checkDiscourseApiKey("   0123456789abcdef0123456789   ");
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
 
 		});
 
 	});
 
-	describe("Checks for good keys", function() {
+	describe("Checks for valid keys", function() {
 
 		it("should return true when the key has a valid syntax.", function () {
 
-			let result = ApiKeyChecker.checkDiscourseApiKey("0123456789abcdef0123456789abcdef");
-			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_IS_NOT_ONLY_LOWERCASE_HEXADECIMALS);
+			let result = checkDiscourseApiKey("0123456789abcdef0123456789abcdef");
 
-			result = ApiKeyChecker.checkDiscourseApiKey("12345678901234567890123456789012");
-			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_IS_NOT_ONLY_LOWERCASE_HEXADECIMALS);
+			expect(result.success).toBe(true);
+			expect(result.error).toBe(apiKeyError.NO_ERROR);
 
-			result = ApiKeyChecker.checkDiscourseApiKey("        0123456789abcdef0123456789abcdef    ");
-			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_IS_NOT_ONLY_LOWERCASE_HEXADECIMALS);
+			result = checkDiscourseApiKey("12345678901234567890123456789012");
 
-			result = ApiKeyChecker.checkDiscourseApiKey("0123456789abcdef0123456789abcdef   ");
-			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_IS_NOT_ONLY_LOWERCASE_HEXADECIMALS);
+			expect(result.success).toBe(true);
+			expect(result.error).toBe(apiKeyError.NO_ERROR);
 
-			result = ApiKeyChecker.checkDiscourseApiKey(" 0123456789abcdef0123456789abcdef");
-			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_IS_NOT_ONLY_LOWERCASE_HEXADECIMALS);
+			result = checkDiscourseApiKey("        0123456789abcdef0123456789abcdef    ");
+
+			expect(result.success).toBe(true);
+			expect(result.error).toBe(apiKeyError.NO_ERROR);
+
+			result = checkDiscourseApiKey("0123456789abcdef0123456789abcdef   ");
+
+			expect(result.success).toBe(true);
+			expect(result.error).toBe(apiKeyError.NO_ERROR);
+
+			result = checkDiscourseApiKey(" 0123456789abcdef0123456789abcdef");
+
+			expect(result.success).toBe(true);
+			expect(result.error).toBe(apiKeyError.NO_ERROR);
 
 		});
 
 		it("should return true when the key has a valid syntax. Uppercase keys should be accepted as well and converted to lowercase.", function () {
 
-			let result = ApiKeyChecker.checkDiscourseApiKey("AEFABBC394030AEFABBC3940309286BE");
-			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_IS_NOT_ONLY_LOWERCASE_HEXADECIMALS);
+			let result = checkDiscourseApiKey("AEFABBC394030AEFABBC3940309286BE");
 
-			result = ApiKeyChecker.checkDiscourseApiKey("AEFaBBC394030aefABBC3940309286BE");
-			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_IS_NOT_ONLY_LOWERCASE_HEXADECIMALS);
+			expect(result.success).toBe(true);
+			expect(result.error).toBe(apiKeyError.NO_ERROR);
 
-			result = ApiKeyChecker.checkDiscourseApiKey("        aAbBcDeEfF12345678900987654321    ");
-			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_IS_NOT_ONLY_LOWERCASE_HEXADECIMALS);
+			result = checkDiscourseApiKey("AEFaBBC394030aefABBC3940309286BE");
 
-			result = ApiKeyChecker.checkDiscourseApiKey("ABC   ");
-			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_IS_NOT_ONLY_LOWERCASE_HEXADECIMALS);
+			expect(result.success).toBe(true);
+			expect(result.error).toBe(apiKeyError.NO_ERROR);
 
-			result = ApiKeyChecker.checkDiscourseApiKey(" 1234567890123456789012345678900A");
-			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_IS_NOT_ONLY_LOWERCASE_HEXADECIMALS);
+			result = checkDiscourseApiKey(" 1234567890123456789012345678900A");
+
+			expect(result.success).toBe(true);
+			expect(result.error).toBe(apiKeyError.NO_ERROR);
 
 		});
 


### PR DESCRIPTION
The code verifies if the api key is undefined, empty or in the wrong format. It formats the key to lower case, because that is needed for the Discourse API. Some of the tests have been changed.