### PR TITLE
Make a class of ApiKeyChecker.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - "12"
+
+addons:
+  chrome: stable #needed for Karma testing

--- a/js/ApiKeyChecker.js
+++ b/js/ApiKeyChecker.js
@@ -1,60 +1,66 @@
-const apiKeyError = {
-	"NO_ERROR":0,
-	"KEY_IS_UNDEFINED_OR_NOT_A_STRING":1,
-	"KEY_IS_EMPTY":2,
-	"KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS":3
-};
-Object.freeze(apiKeyError);
+//Comment the next line to check with Karma. This is because webbrowsers don't understand modules and "require()"
+module.exports =
+	class ApiKeyChecker {
 
+	constructor() {
+		Object.freeze(this.apiKeyError);
+	};
 
-/**
- * Check if the apiKey has the right format before using it.
+	apiKeyError = {
+		"NO_ERROR":0,
+		"KEY_IS_UNDEFINED_OR_NOT_A_STRING":1,
+		"KEY_IS_EMPTY":2,
+		"KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS":3
+	}
+
+	/**
+	 * Check if the apiKey has the right format before using it.
 	 * @param {string} apiKey
 	 * @return {Object} success, error, errorMsg, formattedKey
 	 */
-function checkDiscourseApiKey(apiKey) {
+	checkDiscourseApiKey(apiKey) {
 
-	//check if key is defined
-	if (typeof apiKey == "undefined") {
+		//check if key is defined
+		if (typeof apiKey == "undefined") {
 
+			return {
+				success : false,
+				error : this.apiKeyError.KEY_IS_UNDEFINED_OR_NOT_A_STRING,
+				errorMsg : "'UserApiKey' is not defined in config.js or is not a string.",
+			};
+		}
+
+		apiKey = apiKey.toLowerCase();
+
+		//Remove spaces at the start and end of the key.
+		apiKey = apiKey.trim();
+
+		//check if key is not empty
+		if (apiKey.length === 0) {
+			return {
+				success : false,
+				error : this.apiKeyError.KEY_IS_EMPTY,
+				errorMsg : "'UserApiKey' in config.js is an empty string.",
+			};
+		}
+
+
+		//check if key is a lowercase hexadecimal string
+		if (apiKey.match("^[a-f0-9]{32}$") === null) {
+			return {
+				success : false,
+				error : this.apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS,
+				errorMsg : "The provided API key has a wrong format. It should be a string of 32 hexadecimal numbers.",
+			};
+		}
+
+		//Check passed.
 		return {
-			success : false,
-			error : apiKeyError.KEY_IS_UNDEFINED_OR_NOT_A_STRING,
-			errorMsg : "'UserApiKey' is not defined in config.js or is not a string.",
+			success : true,
+			error : this.apiKeyError.NO_ERROR,
+			errorMsg : "No error",
+			formattedKey : apiKey,
 		};
-	}
-
-	apiKey = apiKey.toLowerCase();
-
-	//Remove spaces at the start and end of the key.
-	apiKey = apiKey.trim();
-
-	//check if key is not empty
-	if (apiKey.length === 0) {
-		return {
-			success : false,
-			error : apiKeyError.KEY_IS_EMPTY,
-			errorMsg : "'UserApiKey' in config.js is an empty string.",
-		};
-	}
-
-
-	//check if key is a lowercase hexadecimal string
-	if (apiKey.match("^[a-f0-9]{32}$") === null) {
-		return {
-			success : false,
-			error : apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS,
-			errorMsg : "The provided API key has a wrong format. It should be a string of 32 hexadecimal numbers.",
-		};
-	}
-
-	//Check passed.
-	return {
-		success : true,
-		error : apiKeyError.NO_ERROR,
-		errorMsg : "No error",
-		formattedKey : apiKey,
 	};
-}
 
-module.exports = {apiKeyError, checkDiscourseApiKey};
+}

--- a/tests/validateUserApiKey_test.js
+++ b/tests/validateUserApiKey_test.js
@@ -1,15 +1,15 @@
-/* global apiKeyError */
-/* eslint-disable jasmine/no-pending-tests */
+const apiKeyChecker = new ApiKeyChecker();
 
 describe("The API key validator", function() {
 
 	describe("Checks for undefined strings", function() {
 
 		it("should return false when the string is undefined.", function () {
-			let result = checkDiscourseApiKey(undefined);
+
+			let result = apiKeyChecker.checkDiscourseApiKey(undefined);
 
 			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_IS_UNDEFINED_OR_NOT_A_STRING);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.KEY_IS_UNDEFINED_OR_NOT_A_STRING);
 		});
 
 	});
@@ -17,15 +17,15 @@ describe("The API key validator", function() {
 	describe("Checks for empty strings", function() {
 
 		it("should return false when the string is defined but empty.", function () {
-			let result = checkDiscourseApiKey("");
+			let result = apiKeyChecker.checkDiscourseApiKey("");
 
 			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_IS_EMPTY);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.KEY_IS_EMPTY);
 
-			result = checkDiscourseApiKey("      ");
+			result = apiKeyChecker.checkDiscourseApiKey("      ");
 
 			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_IS_EMPTY);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.KEY_IS_EMPTY);
 		});
 
 	});
@@ -34,58 +34,58 @@ describe("The API key validator", function() {
 
 		it("should return false when the key is not a (HEX) string of 32 characters.", function () {
 
-			let result = checkDiscourseApiKey("abcdefg12345678");
+			let result = apiKeyChecker.checkDiscourseApiKey("abcdefg12345678");
 
 			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
 
-			result = checkDiscourseApiKey("3820235820efa0i");
-
-			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
-
-			result = checkDiscourseApiKey("true");
+			result = apiKeyChecker.checkDiscourseApiKey("3820235820efa0i");
 
 			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
 
-			result = checkDiscourseApiKey("z");
-
-			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
-
-			result = checkDiscourseApiKey("helloworld");
+			result = apiKeyChecker.checkDiscourseApiKey("true");
 
 			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
 
-			result = checkDiscourseApiKey("000000000000000t0");
+			result = apiKeyChecker.checkDiscourseApiKey("z");
 
 			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
+
+			result = apiKeyChecker.checkDiscourseApiKey("helloworld");
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
+
+			result = apiKeyChecker.checkDiscourseApiKey("000000000000000t0");
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
 		});
 
 		it("should return false when the key contains spaces in the middle.", function () {
 
-			let result = checkDiscourseApiKey("1 2345678901234567890123456789012");
+			let result = apiKeyChecker.checkDiscourseApiKey("1 2345678901234567890123456789012");
 
 			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
 
-			result = checkDiscourseApiKey("1234567890123456789012345678901 2 ");
-
-			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
-
-			result = checkDiscourseApiKey("1234567890123               4567890123456789012");
+			result = apiKeyChecker.checkDiscourseApiKey("1234567890123456789012345678901 2 ");
 
 			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
 
-			result = checkDiscourseApiKey("1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2");
+			result = apiKeyChecker.checkDiscourseApiKey("1234567890123               4567890123456789012");
 
 			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
+
+			result = apiKeyChecker.checkDiscourseApiKey("1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2");
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
 		});
 
 	});
@@ -94,35 +94,35 @@ describe("The API key validator", function() {
 
 		it("should return false when the key does not contain 32 characters.", function () {
 
-			let result = checkDiscourseApiKey("1");
+			let result = apiKeyChecker.checkDiscourseApiKey("1");
 
 			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
 
-			result = checkDiscourseApiKey("123456789012345678901234567890123");
-
-			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
-
-			result = checkDiscourseApiKey("1234567890123456789012345678901");
+			result = apiKeyChecker.checkDiscourseApiKey("123456789012345678901234567890123");
 
 			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
 
-			result = checkDiscourseApiKey("0123456789abcdef0123456789abcdef0");
-
-			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
-
-			result = checkDiscourseApiKey("0123456789abcdef0123456789abcde");
+			result = apiKeyChecker.checkDiscourseApiKey("1234567890123456789012345678901");
 
 			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
 
-			result = checkDiscourseApiKey("   0123456789abcdef0123456789   ");
+			result = apiKeyChecker.checkDiscourseApiKey("0123456789abcdef0123456789abcdef0");
 
 			expect(result.success).toBe(false);
-			expect(result.error).toBe(apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
+
+			result = apiKeyChecker.checkDiscourseApiKey("0123456789abcdef0123456789abcde");
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
+
+			result = apiKeyChecker.checkDiscourseApiKey("   0123456789abcdef0123456789   ");
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.KEY_DOES_NOT_EQUAL_32_HEXADECIMAL_NUMBERS);
 
 		});
 
@@ -132,49 +132,49 @@ describe("The API key validator", function() {
 
 		it("should return true when the key has a valid syntax.", function () {
 
-			let result = checkDiscourseApiKey("0123456789abcdef0123456789abcdef");
+			let result = apiKeyChecker.checkDiscourseApiKey("0123456789abcdef0123456789abcdef");
 
 			expect(result.success).toBe(true);
-			expect(result.error).toBe(apiKeyError.NO_ERROR);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.NO_ERROR);
 
-			result = checkDiscourseApiKey("12345678901234567890123456789012");
-
-			expect(result.success).toBe(true);
-			expect(result.error).toBe(apiKeyError.NO_ERROR);
-
-			result = checkDiscourseApiKey("        0123456789abcdef0123456789abcdef    ");
+			result = apiKeyChecker.checkDiscourseApiKey("12345678901234567890123456789012");
 
 			expect(result.success).toBe(true);
-			expect(result.error).toBe(apiKeyError.NO_ERROR);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.NO_ERROR);
 
-			result = checkDiscourseApiKey("0123456789abcdef0123456789abcdef   ");
-
-			expect(result.success).toBe(true);
-			expect(result.error).toBe(apiKeyError.NO_ERROR);
-
-			result = checkDiscourseApiKey(" 0123456789abcdef0123456789abcdef");
+			result = apiKeyChecker.checkDiscourseApiKey("        0123456789abcdef0123456789abcdef    ");
 
 			expect(result.success).toBe(true);
-			expect(result.error).toBe(apiKeyError.NO_ERROR);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.NO_ERROR);
+
+			result = apiKeyChecker.checkDiscourseApiKey("0123456789abcdef0123456789abcdef   ");
+
+			expect(result.success).toBe(true);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.NO_ERROR);
+
+			result = apiKeyChecker.checkDiscourseApiKey(" 0123456789abcdef0123456789abcdef");
+
+			expect(result.success).toBe(true);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.NO_ERROR);
 
 		});
 
 		it("should return true when the key has a valid syntax. Uppercase keys should be accepted as well and converted to lowercase.", function () {
 
-			let result = checkDiscourseApiKey("AEFABBC394030AEFABBC3940309286BE");
+			let result = apiKeyChecker.checkDiscourseApiKey("AEFABBC394030AEFABBC3940309286BE");
 
 			expect(result.success).toBe(true);
-			expect(result.error).toBe(apiKeyError.NO_ERROR);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.NO_ERROR);
 
-			result = checkDiscourseApiKey("AEFaBBC394030aefABBC3940309286BE");
-
-			expect(result.success).toBe(true);
-			expect(result.error).toBe(apiKeyError.NO_ERROR);
-
-			result = checkDiscourseApiKey(" 1234567890123456789012345678900A");
+			result = apiKeyChecker.checkDiscourseApiKey("AEFaBBC394030aefABBC3940309286BE");
 
 			expect(result.success).toBe(true);
-			expect(result.error).toBe(apiKeyError.NO_ERROR);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.NO_ERROR);
+
+			result = apiKeyChecker.checkDiscourseApiKey(" 1234567890123456789012345678900A");
+
+			expect(result.success).toBe(true);
+			expect(result.error).toBe(apiKeyChecker.apiKeyError.NO_ERROR);
 
 		});
 


### PR DESCRIPTION
Instead of exporting functions and variables, the file is now a class. The functionality can still be tested by removing the first line of real code in ApiKeyChecker.js.